### PR TITLE
Move camera with player

### DIFF
--- a/docs/main.typ
+++ b/docs/main.typ
@@ -7,9 +7,9 @@ by Casey Walker and Grace Xin
 The main objective of the game: _keep your campfire alive_.
 
 This is a 2.5D game where the player is plays a character that needs to keep the
-  campfire from dying.
+campfire from dying.
 The campfire will burn through its fuel over time, so the player must move
-  around the world and collect fuel to bring back to the campfire.
+around the world and collect fuel to bring back to the campfire.
 
 == Minimum goals
 
@@ -18,20 +18,35 @@ As a minimum for submission, we are planning to implement the following:
 - a campfire with a time-based deteriorating meter, which can be fed fuel
   - the meter is a static HUD element (e.g. a bar)
   - the campfire does not visually change based on the meter level---it will
-      always be the provided assets required by the game jam criteria
+    always be the provided assets required by the game jam criteria
 - collectable fuels that can be stored and fed to the campfire
   - sticks/twigs laying on the ground
   - wood logs that can be picked up from set locations
 - a character that can move around the world and interact with fuels and the
-    campfire
+  campfire
 - environments for the player to travel between
   - the campsite (where teh fire is located)
   - a forest, where sticks and logs can be gathered
 
+== Progress
+- #text(fill: green)[campfire]
+  - #text(fill: red)[meter]
+- #text(fill: red)[fuels] (note: either autogenerate locations or hardcode them, but this will probably come after environments are built)
+  - #text(fill: red)[sticks]
+  - #text(fill: red)[logs]
+- #text(fill: orange)[player] (replace temp png)
+  - #text(fill: orange)[movement] (gotta redo it all FUUUUUCK)
+- #text(fill: orange)[environments]
+  - #text(fill: orange)[campsite] (replace temp png)
+  - #text(fill: orange)[forest] (replace temp png, spawn at edge of screen, have entrance to teleport back to campsite)
+- #text(fill: red)[interactions]
+  - #text(fill: red)[pick up fuels]
+  - #text(fill: red)[feed campfire]
+
 === General tasks that can be parallelized
 
 In general, we will can divide the work into the following parallelizable
-  categories:
+categories:
 
 - campfire meter HUD
 - player interaction, such as moving and picking up items

--- a/docs/main.typ
+++ b/docs/main.typ
@@ -7,9 +7,9 @@ by Casey Walker and Grace Xin
 The main objective of the game: _keep your campfire alive_.
 
 This is a 2.5D game where the player is plays a character that needs to keep the
-campfire from dying.
+  campfire from dying.
 The campfire will burn through its fuel over time, so the player must move
-around the world and collect fuel to bring back to the campfire.
+  around the world and collect fuel to bring back to the campfire.
 
 == Minimum goals
 
@@ -18,12 +18,12 @@ As a minimum for submission, we are planning to implement the following:
 - a campfire with a time-based deteriorating meter, which can be fed fuel
   - the meter is a static HUD element (e.g. a bar)
   - the campfire does not visually change based on the meter level---it will
-    always be the provided assets required by the game jam criteria
+      always be the provided assets required by the game jam criteria
 - collectable fuels that can be stored and fed to the campfire
   - sticks/twigs laying on the ground
   - wood logs that can be picked up from set locations
 - a character that can move around the world and interact with fuels and the
-  campfire
+    campfire
 - environments for the player to travel between
   - the campsite (where teh fire is located)
   - a forest, where sticks and logs can be gathered
@@ -31,14 +31,16 @@ As a minimum for submission, we are planning to implement the following:
 == Progress
 - #text(fill: green)[campfire]
   - #text(fill: red)[meter]
-- #text(fill: red)[fuels] (note: either autogenerate locations or hardcode them, but this will probably come after environments are built)
+- #text(fill: red)[fuels] (note: either autogenerate locations or hardcode them,
+    but this will probably come after environments are built)
   - #text(fill: red)[sticks]
   - #text(fill: red)[logs]
 - #text(fill: orange)[player] (replace temp png)
   - #text(fill: orange)[movement] (gotta redo it all FUUUUUCK)
 - #text(fill: orange)[environments]
   - #text(fill: orange)[campsite] (replace temp png)
-  - #text(fill: orange)[forest] (replace temp png, spawn at edge of screen, have entrance to teleport back to campsite)
+  - #text(fill: orange)[forest] (replace temp png, spawn at edge of screen, have
+      entrance to teleport back to campsite)
 - #text(fill: red)[interactions]
   - #text(fill: red)[pick up fuels]
   - #text(fill: red)[feed campfire]
@@ -46,7 +48,7 @@ As a minimum for submission, we are planning to implement the following:
 === General tasks that can be parallelized
 
 In general, we will can divide the work into the following parallelizable
-categories:
+  categories:
 
 - campfire meter HUD
 - player interaction, such as moving and picking up items

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ pub mod background;
 pub mod campfire;
 pub mod campsite;
 mod campsite_forest_entrance;
-pub mod constants;
 pub mod forest;
 pub mod input_bindings;
 pub mod player;
@@ -24,8 +23,7 @@ fn main() {
         .add_plugins(GifPlugin)
         .init_state::<GameState>()
         .init_resource::<input_bindings::KeyBinds>()
-        .add_systems(Startup, setup)
-        .add_systems(Startup, player::setup.after(setup))
+        .add_systems(Startup, player::setup)
         .add_systems(OnEnter(GameState::Forest), forest::setup)
         .add_systems(
             OnEnter(GameState::Campsite),
@@ -47,10 +45,6 @@ fn main() {
         )
         .add_systems(Update, (y_sort::y_sort, handle_quit))
         .run();
-}
-
-fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d::default());
 }
 
 fn handle_quit(

--- a/src/player.rs
+++ b/src/player.rs
@@ -15,22 +15,25 @@ pub struct Player;
 const PLAYER_SPEED: f32 = 500.;
 pub const PLAYER_SIZE: Vec2 = Vec2::new(30., 50.);
 const PLAYER_STARTING_POS: Vec2 = Vec2::new(-PLAYER_SIZE.x, DEFAULT_POS.y);
-const EDGE_BUFFER: f32 = 200.;
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn((
-        (
-            Sprite {
-                custom_size: Some(PLAYER_SIZE),
-                image: asset_server.load("player.png"),
-                ..default()
-            },
-            Anchor::BOTTOM_CENTER,
-            Transform::from_translation(PLAYER_STARTING_POS.extend(DEFAULT_Z)),
-        ),
-        Player,
-        YSort { z: z_indices::MIDGROUND },
-    ));
+    commands
+        .spawn((
+            (
+                Sprite {
+                    custom_size: Some(PLAYER_SIZE),
+                    image: asset_server.load("player.png"),
+                    ..default()
+                },
+                Anchor::BOTTOM_CENTER,
+                Transform::from_translation(
+                    PLAYER_STARTING_POS.extend(DEFAULT_Z),
+                ),
+            ),
+            Player,
+            YSort { z: z_indices::MIDGROUND },
+        ))
+        .with_child(Camera2d::default());
 }
 
 /// Returns a direction vector based on the currently pressed movement keys (WASD or arrow keys)
@@ -56,93 +59,12 @@ fn get_direction(
     direction
 }
 
-/// Returns (player_delta, world_delta) for one axis.
-fn resolve_axis(
-    player_pos: f32,
-    player_extent: f32, // half-height or half-width for screen edge check
-    site_pos: f32,
-    half_bg: f32,
-    half_screen: f32,
-    limit: f32,
-    movement: f32,
-) -> (f32, f32) {
-    let moving_outwards = (player_pos + movement).abs() > player_pos.abs();
-
-    if player_pos.abs() < limit || !moving_outwards {
-        let new_pos = player_pos + movement;
-        if (new_pos + player_extent).abs() < half_screen {
-            (movement, 0.)
-        } else {
-            (0., 0.)
-        }
-    } else {
-        // Buffer zone, moving deeper — try scrolling the world
-        let new_site_pos = site_pos - movement;
-        let site_near_edge = new_site_pos - half_bg; // left or bottom
-        let site_far_edge = new_site_pos + half_bg; // right or top
-
-        if site_near_edge <= -half_screen && site_far_edge >= half_screen {
-            (0., -movement)
-        } else {
-            // Campsite at its limit — move player if still on screen
-            let new_pos = player_pos + movement;
-            if (new_pos + player_extent).abs() < half_screen {
-                (movement, 0.)
-            } else {
-                (0., 0.)
-            }
-        }
-    }
-}
-
 pub fn movement(
     keyboard: Res<ButtonInput<KeyCode>>,
     key_binds: Res<KeyBinds>,
     time: Res<Time>,
-    window_query: Query<&Window, With<PrimaryWindow>>,
-    game_state: Res<State<GameState>>,
-    mut queries: ParamSet<(
-        Query<&Transform, With<Campsite>>, // p0: read campsite pos
-        Query<&Transform, With<Forest>>,   // p1: read forest pos
-        Query<&mut Transform, With<Background>>, // p2: move all bgs
-        Query<&mut Transform, With<Player>>, // p3: move player
-    )>,
+    mut player_query: Query<&mut Transform, With<Player>>,
 ) {
-    let Ok(window) = window_query.single() else {
-        println!("early return: no window");
-        return;
-    };
-    let background = match game_state.get() {
-        GameState::Campsite => {
-            let campsite_query = queries.p0();
-            let Ok(t) = campsite_query.single() else {
-                println!("early return: no campsite");
-                return;
-            };
-            t.translation
-        },
-        GameState::Forest => {
-            let forest_query = queries.p1();
-            let Ok(t) = forest_query.single() else {
-                println!("early return: no forest");
-                return;
-            };
-            t.translation
-        },
-    };
-    let player = {
-        let player_query = queries.p3();
-        let Ok(t) = player_query.single() else {
-            println!("early return: no player");
-            return;
-        };
-        t.translation
-    };
-
-    let half_screen = Vec2::new(window.width(), window.height()) / 2.;
-    let half_bg = BACKGROUND_SIZE / 2.;
-    let limit = half_screen - Vec2::splat(EDGE_BUFFER);
-
     let direction = get_direction(keyboard, key_binds);
     if direction == Vec3::ZERO {
         return;
@@ -151,36 +73,9 @@ pub fn movement(
     let movement =
         direction.normalize_or_zero() * PLAYER_SPEED * time.delta_secs();
 
-    let (pdx, wdx) = resolve_axis(
-        player.x,
-        0., // x: anchor is center, no extent needed
-        background.x,
-        half_bg.x,
-        half_screen.x,
-        limit.x,
-        movement.x,
-    );
-    let (pdy, wdy) = resolve_axis(
-        player.y,
-        PLAYER_SIZE.y / 2., // y: anchor is bottom, offset by half height
-        background.y,
-        half_bg.y,
-        half_screen.y,
-        limit.y,
-        movement.y,
-    );
-
-    let mut player_query = queries.p3();
-    let Ok(mut pt) = player_query.single_mut() else {
+    let Ok(mut player) = player_query.single_mut() else {
         return;
     };
-    pt.translation.x += pdx;
-    pt.translation.y += pdy;
-    drop(player_query);
-
-    let mut bg_query = queries.p2();
-    for mut bg in bg_query.iter_mut() {
-        bg.translation.x += wdx;
-        bg.translation.y += wdy;
-    }
+    player.translation.x += movement.x;
+    player.translation.y += movement.y;
 }


### PR DESCRIPTION
Fixes #11 
Simplifies player movement a lot (no more wonky background/other object movement)

Currently this implementation allows moving past rendered backgrounds. However this can be solved via adding decor/landscaping barriers within the bounds of the rendered background (e.g. fences, shrubs, trees, cliffs) to prevent the player+camera from moving past the background's borders.
