### PR TITLE
Campfire meter

### DIFF
--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -5,6 +5,8 @@ use bevy_easy_gif::*;
 use crate::background::on_add_background;
 use crate::y_sort::{DEFAULT_POS, DEFAULT_Z, YSort, z_indices};
 
+/// The campfire is the central part of the game that the player must interact
+/// with. It will burn through fuel over time.
 #[derive(Component)]
 #[component(on_add = on_add_background)]
 pub struct Campfire;

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -38,29 +38,6 @@ pub struct CampfireMeter {
     percent: f32,
 }
 
-impl Default for Campfire {
-    fn default() -> Self {
-        Self { fuel: Self::STARTING_FUEL, capacity: Self::STARTING_FUEL }
-    }
-}
-
-impl Default for CampfireFuelBurn {
-    fn default() -> Self {
-        Self {
-            burn_timer: Timer::from_seconds(
-                Self::BURN_RATE,
-                TimerMode::Repeating,
-            ),
-        }
-    }
-}
-
-impl Default for CampfireMeter {
-    fn default() -> Self {
-        Self { percent: 100. }
-    }
-}
-
 impl Campfire {
     /// The default amount of starting fuel for the campfire.
     const STARTING_FUEL: f32 = 60.; // 1 minute
@@ -164,5 +141,28 @@ impl Plugin for CampfirePlugin {
             (CampfireMeter::update, CampfireFuelBurn::update),
         )
         .add_observer(CampfireMeter::setup);
+    }
+}
+
+impl Default for Campfire {
+    fn default() -> Self {
+        Self { fuel: Self::STARTING_FUEL, capacity: Self::STARTING_FUEL }
+    }
+}
+
+impl Default for CampfireFuelBurn {
+    fn default() -> Self {
+        Self {
+            burn_timer: Timer::from_seconds(
+                Self::BURN_RATE,
+                TimerMode::Repeating,
+            ),
+        }
+    }
+}
+
+impl Default for CampfireMeter {
+    fn default() -> Self {
+        Self { percent: 100. }
     }
 }

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -87,7 +87,7 @@ impl CampfireFuelBurn {
 impl CampfireMeter {
     const WIDTH: Val = Val::Px(250.);
     const HEIGHT: Val = Val::Px(40.);
-    const BORDER_WIDTH: UiRect = UiRect::all(Val::Px(3.0));
+    const BORDER_WIDTH: UiRect = UiRect::all(Val::Px(3.));
 
     const FILL_COLOR: Color = Color::linear_rgb(0.3, 0.1, 0.1);
     const BORDER_COLOR: Color = Color::linear_rgb(0.7, 0.7, 0.7);

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -23,15 +23,53 @@ pub struct Campfire {
     capacity: f32,
 }
 
+/// This component causes the campfire to burn through its fuel based on a burn
+/// timer.
+#[derive(Component)]
+pub struct CampfireFuelBurn {
+    /// The timer that controls how often fuel is burned. Every time the timer
+    /// is exhausted, some fuel will be removed from the campfire.
+    burn_timer: Timer,
+}
+
 impl Default for Campfire {
     fn default() -> Self {
         Self { fuel: Self::STARTING_FUEL, capacity: Self::STARTING_FUEL }
     }
 }
 
+impl Default for CampfireFuelBurn {
+    fn default() -> Self {
+        Self {
+            burn_timer: Timer::from_seconds(
+                Self::BURN_RATE,
+                TimerMode::Repeating,
+            ),
+        }
+    }
+}
+
 impl Campfire {
     /// The default amount of starting fuel for the campfire.
     const STARTING_FUEL: f32 = 60.; // 1 minute
+}
+
+impl CampfireFuelBurn {
+    /// The default burn rate of the campfire, in seconds.
+    const BURN_RATE: f32 = 1.;
+
+    fn update(
+        query: Query<(&mut Campfire, &mut CampfireFuelBurn)>,
+        time: Res<Time>,
+    ) {
+        for (mut campfire, mut fuel_burn) in query {
+            fuel_burn.burn_timer.tick(time.delta());
+
+            if fuel_burn.burn_timer.just_finished() {
+                campfire.fuel -= 1.;
+            }
+        }
+    }
 }
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -32,6 +32,12 @@ pub struct CampfireFuelBurn {
     burn_timer: Timer,
 }
 
+/// The visual aspect of the campfire, showing how much fuel is left.
+#[derive(Component)]
+pub struct CampfireMeter {
+    percent: f32,
+}
+
 impl Default for Campfire {
     fn default() -> Self {
         Self { fuel: Self::STARTING_FUEL, capacity: Self::STARTING_FUEL }
@@ -46,6 +52,12 @@ impl Default for CampfireFuelBurn {
                 TimerMode::Repeating,
             ),
         }
+    }
+}
+
+impl Default for CampfireMeter {
+    fn default() -> Self {
+        Self { percent: 100. }
     }
 }
 
@@ -68,6 +80,53 @@ impl CampfireFuelBurn {
             if fuel_burn.burn_timer.just_finished() {
                 campfire.fuel -= 1.;
             }
+        }
+    }
+}
+
+impl CampfireMeter {
+    const WIDTH: Val = Val::Px(250.);
+    const HEIGHT: Val = Val::Px(40.);
+    const BORDER_WIDTH: UiRect = UiRect::all(Val::Px(3.0));
+
+    const FILL_COLOR: Color = Color::linear_rgb(0.3, 0.1, 0.1);
+    const BORDER_COLOR: Color = Color::linear_rgb(0.7, 0.7, 0.7);
+
+    /// Whenever a campfire is spawned, add a campfire meter to the it to
+    /// display the amount of fuel left.
+    fn setup_meter(add: On<Add, Campfire>, mut commands: Commands) {
+        commands
+            .entity(add.entity)
+            .insert((CampfireMeter::default(), CampfireFuelBurn::default()))
+            .insert((
+                Node {
+                    width: Self::WIDTH,
+                    height: Self::HEIGHT,
+                    border: Self::BORDER_WIDTH,
+                    ..default()
+                },
+                BackgroundColor(Color::BLACK),
+                BorderColor::all(Self::BORDER_COLOR),
+            ))
+            .with_children(|parent| {
+                parent.spawn((
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Percent(100.0),
+                        ..default()
+                    },
+                    BackgroundColor(Self::FILL_COLOR),
+                    CampfireMeter { percent: 100.0 },
+                ));
+            });
+    }
+
+    /// Update the campfire meter's fill percent with the campfire's current
+    /// state.
+    fn update(query: Query<(&mut CampfireMeter, &Campfire, &mut Node)>) {
+        for (mut meter, campfire, mut node) in query {
+            meter.percent = campfire.fuel / campfire.capacity * 100.;
+            node.width = Val::Percent(meter.percent);
         }
     }
 }

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -116,7 +116,6 @@ impl CampfireMeter {
                         ..default()
                     },
                     BackgroundColor(Self::FILL_COLOR),
-                    CampfireMeter { percent: 100.0 },
                 ));
             });
     }

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -7,9 +7,32 @@ use crate::y_sort::{DEFAULT_POS, DEFAULT_Z, YSort, z_indices};
 
 /// The campfire is the central part of the game that the player must interact
 /// with. It will burn through fuel over time.
+///
+/// Campfire fuel represents the number of seconds (in-game time) that the fire
+/// has left before it dies and the game is over. Different fuels will have
+/// different effects on the campfire. Some will simply prolong the campfire's
+/// life by increasing its fuel (up to the capacity), others may increase the
+/// capacity itself.
 #[derive(Component)]
 #[component(on_add = on_add_background)]
-pub struct Campfire;
+pub struct Campfire {
+    /// The amount of fuel the campfire has left to burn.
+    fuel: u32,
+
+    /// The maximum amount of fuel the campfire can hold.
+    capacity: u32,
+}
+
+impl Default for Campfire {
+    fn default() -> Self {
+        Self { fuel: Self::STARTING_FUEL, capacity: Self::STARTING_FUEL }
+    }
+}
+
+impl Campfire {
+    /// The default amount of starting fuel for the campfire.
+    const STARTING_FUEL: u32 = 60; // 1 minute
+}
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
@@ -18,7 +41,7 @@ pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             Anchor::BOTTOM_CENTER,
             Transform::from_translation(DEFAULT_POS.extend(DEFAULT_Z)),
         ),
-        Campfire,
+        Campfire::default(),
         YSort { z: z_indices::MIDGROUND },
     ));
 }

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -17,10 +17,10 @@ use crate::y_sort::{DEFAULT_POS, DEFAULT_Z, YSort, z_indices};
 #[component(on_add = on_add_background)]
 pub struct Campfire {
     /// The amount of fuel the campfire has left to burn.
-    fuel: u32,
+    fuel: f32,
 
     /// The maximum amount of fuel the campfire can hold.
-    capacity: u32,
+    capacity: f32,
 }
 
 impl Default for Campfire {
@@ -31,7 +31,7 @@ impl Default for Campfire {
 
 impl Campfire {
     /// The default amount of starting fuel for the campfire.
-    const STARTING_FUEL: u32 = 60; // 1 minute
+    const STARTING_FUEL: f32 = 60.; // 1 minute
 }
 
 pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -5,6 +5,18 @@ use bevy_easy_gif::*;
 use crate::background::on_add_background;
 use crate::y_sort::{DEFAULT_POS, DEFAULT_Z, YSort, z_indices};
 
+pub struct CampfirePlugin;
+
+impl Plugin for CampfirePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            FixedUpdate,
+            (CampfireMeter::update, CampfireFuelBurn::update),
+        )
+        .add_observer(CampfireMeter::setup);
+    }
+}
+
 /// The campfire is the central part of the game that the player must interact
 /// with. It will burn through fuel over time.
 ///
@@ -129,18 +141,6 @@ pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 pub fn teardown(mut commands: Commands, query: Query<Entity, With<Campfire>>) {
     for entity in query.iter() {
         commands.entity(entity).despawn();
-    }
-}
-
-pub struct CampfirePlugin;
-
-impl Plugin for CampfirePlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(
-            FixedUpdate,
-            (CampfireMeter::update, CampfireFuelBurn::update),
-        )
-        .add_observer(CampfireMeter::setup);
     }
 }
 

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -148,3 +148,15 @@ pub fn teardown(mut commands: Commands, query: Query<Entity, With<Campfire>>) {
         commands.entity(entity).despawn();
     }
 }
+
+pub struct CampfirePlugin;
+
+impl Plugin for CampfirePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            FixedUpdate,
+            (CampfireMeter::update, CampfireFuelBurn::update),
+        )
+        .add_observer(CampfireMeter::setup_meter);
+    }
+}

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 use bevy::sprite::Anchor;
 use bevy_easy_gif::*;
 
+use crate::GameState;
 use crate::background::on_add_background;
 use crate::y_sort::{DEFAULT_POS, DEFAULT_Z, YSort, z_indices};
 
@@ -13,6 +14,8 @@ impl Plugin for CampfirePlugin {
             FixedUpdate,
             (CampfireMeter::update, CampfireFuelBurn::update),
         )
+        .add_systems(OnEnter(GameState::Campsite), Campfire::setup)
+        .add_systems(OnExit(GameState::Campsite), Campfire::teardown)
         .add_observer(CampfireMeter::setup);
     }
 }
@@ -53,6 +56,26 @@ pub struct CampfireMeter {
 impl Campfire {
     /// The default amount of starting fuel for the campfire.
     const STARTING_FUEL: f32 = 60.; // 1 minute
+
+    fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+        commands.spawn((
+            (
+                Gif {
+                    handle: asset_server.load("campfire/campfire_preview.gif"),
+                },
+                Anchor::BOTTOM_CENTER,
+                Transform::from_translation(DEFAULT_POS.extend(DEFAULT_Z)),
+            ),
+            Campfire::default(),
+            YSort { z: z_indices::MIDGROUND },
+        ));
+    }
+
+    fn teardown(mut commands: Commands, query: Query<Entity, With<Campfire>>) {
+        for entity in query.iter() {
+            commands.entity(entity).despawn();
+        }
+    }
 }
 
 impl CampfireFuelBurn {
@@ -123,24 +146,6 @@ impl CampfireMeter {
                 }
             }
         }
-    }
-}
-
-pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn((
-        (
-            Gif { handle: asset_server.load("campfire/campfire_preview.gif") },
-            Anchor::BOTTOM_CENTER,
-            Transform::from_translation(DEFAULT_POS.extend(DEFAULT_Z)),
-        ),
-        Campfire::default(),
-        YSort { z: z_indices::MIDGROUND },
-    ));
-}
-
-pub fn teardown(mut commands: Commands, query: Query<Entity, With<Campfire>>) {
-    for entity in query.iter() {
-        commands.entity(entity).despawn();
     }
 }
 

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -94,7 +94,7 @@ impl CampfireMeter {
 
     /// Whenever a campfire is spawned, add a campfire meter to the it to
     /// display the amount of fuel left.
-    fn setup_meter(add: On<Add, Campfire>, mut commands: Commands) {
+    fn setup(add: On<Add, Campfire>, mut commands: Commands) {
         commands
             .entity(add.entity)
             .insert((CampfireMeter::default(), CampfireFuelBurn::default()))
@@ -163,6 +163,6 @@ impl Plugin for CampfirePlugin {
             FixedUpdate,
             (CampfireMeter::update, CampfireFuelBurn::update),
         )
-        .add_observer(CampfireMeter::setup_meter);
+        .add_observer(CampfireMeter::setup);
     }
 }

--- a/src/campfire.rs
+++ b/src/campfire.rs
@@ -122,10 +122,17 @@ impl CampfireMeter {
 
     /// Update the campfire meter's fill percent with the campfire's current
     /// state.
-    fn update(query: Query<(&mut CampfireMeter, &Campfire, &mut Node)>) {
-        for (mut meter, campfire, mut node) in query {
+    fn update(
+        query: Query<(&mut CampfireMeter, &Campfire, &Children), With<Node>>,
+        mut fill_query: Query<&mut Node>,
+    ) {
+        for (mut meter, campfire, children) in query {
             meter.percent = campfire.fuel / campfire.capacity * 100.;
-            node.width = Val::Percent(meter.percent);
+            if let Some(&fill) = children.first() {
+                if let Ok(mut fill) = fill_query.get_mut(fill) {
+                    fill.width = Val::Percent(meter.percent);
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy_easy_gif::*;
 
+use crate::campfire::CampfirePlugin;
+
 pub mod background;
 pub mod campfire;
 pub mod campsite;
@@ -46,6 +48,7 @@ fn main() {
                 .after(player::setup),
         )
         .add_systems(Update, (y_sort::y_sort, handle_quit))
+        .add_plugins(CampfirePlugin)
         .run();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ pub mod background;
 pub mod campfire;
 pub mod campsite;
 mod campsite_forest_entrance;
-pub mod constants;
 pub mod forest;
 pub mod input_bindings;
 pub mod player;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,16 +30,12 @@ fn main() {
         .add_systems(OnEnter(GameState::Forest), forest::setup)
         .add_systems(
             OnEnter(GameState::Campsite),
-            (campsite::setup, campfire::setup, campsite_forest_entrance::setup),
+            (campsite::setup, campsite_forest_entrance::setup),
         )
         .add_systems(OnExit(GameState::Forest), forest::teardown)
         .add_systems(
             OnExit(GameState::Campsite),
-            (
-                campsite::teardown,
-                campfire::teardown,
-                campsite_forest_entrance::teardown,
-            ),
+            (campsite::teardown, campsite_forest_entrance::teardown),
         )
         .add_systems(
             FixedUpdate,


### PR DESCRIPTION
Adds a meter in the top-left of the screen that counts decreases over time. The meter is coupled to the campfire's fuel level. Also contains a plugin to modularize some of the campfire logic so it's not all in `main.rs`.